### PR TITLE
Fix build errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "@wordpress/scripts": "^9.0.0"
   },
   "scripts": {
-    "build": "wp-scripts build ./scripts/src/blocks.js --output-path=scripts",
-    "start": "wp-scripts start ./scripts/src/blocks.js --output-path=scripts",
+    "build": "wp-scripts build ./scripts/src/blocks/blocks.js --output-path=scripts",
+    "start": "wp-scripts start ./scripts/src/blocks/blocks.js --output-path=scripts",
     "lint": "wp-scripts lint-js ./scripts/src"
   }
 }

--- a/scripts/src/blocks/blocks.js
+++ b/scripts/src/blocks/blocks.js
@@ -1,1 +1,1 @@
-import './blocks/callout';
+import './callout';


### PR DESCRIPTION
This PR updates two paths to resolve build errors:
- In `package.json`: The path to `blocks.json`.
- In `scripts/src/blocks/blocks.json`: The path to the `callout` directory.

Note:
If using Node 17, running `npm run build` can also produce an error regarding digital envelopes.
To resolve this, run `npm audit fix --force` and run `npm run build` again.