### PR TITLE
Tooling: Limit how often the assets are pushed to WordPress.org

### DIFF
--- a/.github/workflows/asset-readme.yml
+++ b/.github/workflows/asset-readme.yml
@@ -1,14 +1,21 @@
 name: Plugin asset/readme update
+
 on:
   push:
     branches:
-    - main
+      - main
+    paths:
+      - '.wordpress-org/**'
+      - 'readme.txt'
+
 jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable
       env:


### PR DESCRIPTION
This adds a path check to not run the action unless the readme, or `.wordpress-org` asset directories have changes included in the pushed commits.